### PR TITLE
HOTFIX: Resolve Gradle Version Mismatch in GitHub Actions Workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,18 +20,18 @@ jobs:
           cache: gradle
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/gradle-build-action@v3
         with:
-          gradle-version: 6.7.1
+          gradle-version: 7.4
+          
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
           
       - name: Show Gradle version
-        run: gradle --version
+        run: ./gradlew --version
       
-      - name: Debug - List Java files
-        run: find . -name "*.java" -type f | xargs cat
-        
       - name: Build APK with detailed logging
-        run: gradle assembleProductionDebug --debug
+        run: ./gradlew assembleProductionDebug --info
         
       - name: List APK directory
         run: find app/build/outputs -name "*.apk" | sort

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.4' // Updated to be compatible with newer libraries
+        classpath 'com.android.tools.build:gradle:7.2.2' // Updated to be compatible with Gradle 7.4
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## 🚨 URGENT HOTFIX 🚨

This PR fixes the immediate build failure by updating three critical files:

1. **GitHub Actions Workflow**
   - Updated to use Gradle 7.4 instead of 6.7.1
   - Switched to gradle-build-action@v3 for better compatibility
   - Added proper execute permissions for gradlew
   - Updated to use ./gradlew instead of gradle command

2. **Gradle Wrapper Properties**
   - Set to use Gradle 7.4 with bin distribution type

3. **Build Configuration**
   - Updated Android Gradle Plugin to 7.2.2 (compatible with Gradle 7.4)

The error in the build log showed:
```
Failed to apply plugin 'com.android.internal.version-check'.
Minimum supported Gradle version is 7.0.2. Current version is 6.7.1.
```

This hotfix addresses this specific issue by ensuring the Gradle version in the workflow matches what's specified in gradle-wrapper.properties.

**Note:** After merging, we will still need to regenerate the binary gradle-wrapper.jar file locally with:
```bash
./gradlew wrapper --gradle-version 7.4 --distribution-type bin
```
Then commit and push those regenerated binary files.