### PR TITLE
CRITICAL HOTFIX: Simplify Gradle Approach by Using Wrapper Directly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,19 +19,14 @@ jobs:
           distribution: 'temurin'
           cache: gradle
 
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          gradle-version: 6.7.1
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
           
       - name: Show Gradle version
-        run: gradle --version
+        run: ./gradlew --version
       
-      - name: Debug - List Java files
-        run: find . -name "*.java" -type f | xargs cat
-        
       - name: Build APK with detailed logging
-        run: gradle assembleProductionDebug --debug
+        run: ./gradlew assembleProductionDebug --info
         
       - name: List APK directory
         run: find app/build/outputs -name "*.apk" | sort

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.4' // Updated to be compatible with newer libraries
+        classpath 'com.android.tools.build:gradle:7.2.2' // Updated to be compatible with Gradle 7.4
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## CRITICAL HOTFIX - SIMPLIFIED APPROACH

This PR simplifies the hotfix approach by:

1. **Removing the Gradle Setup Step Entirely**
   - No longer using external Gradle setup action
   - Using the project's Gradle wrapper directly with `./gradlew`
   - Adding execute permissions for the wrapper script

2. **Updating Gradle Wrapper Properties**
   - Set to use Gradle 7.4 with bin distribution

3. **Updating Android Gradle Plugin**
   - Updated to version 7.2.2 which is compatible with Gradle 7.4

This eliminates the specific error we're seeing:
```
Minimum supported Gradle version is 7.0.2. Current version is 6.7.1.
```

By using the wrapper directly and removing the setup step that might be overriding our configuration, we should avoid the versioning conflict.

**Important:** The binary files (like gradle-wrapper.jar) will still need to be regenerated locally after merging.