### PR TITLE
Fix night theme reference to missing color

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -5,7 +5,7 @@
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/colorPrimaryDark</item>
         <item name="colorPrimaryDark">#000000</item>
-        <item name="colorAccent">@color/colorAccentDark</item>
+        <item name="colorAccent">@color/accent_dark</item>
         
         <!-- Card colors -->
         <item name="cardBackgroundColor">#2D2D2D</item>


### PR DESCRIPTION
This PR fixes an additional issue with the night theme:

The night theme was referencing a color named `colorAccentDark` that doesn't exist in the colors.xml files. Updated it to use the existing `accent_dark` color instead.

This fix complements the changes in PR #10 to fix the compilation issues. Both PRs should be merged to ensure the project compiles correctly.