### PR TITLE
All fixes for compiling TixelCheckAndroid

### DIFF
--- a/GRADLE-FIX.md
+++ b/GRADLE-FIX.md
@@ -1,0 +1,31 @@
+# Gradle Wrapper Fix
+
+The Gradle wrapper JAR file in this repository is corrupted or missing. Follow these steps to regenerate it:
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/AiGentMaster/TixelCheckAndroid.git
+   cd TixelCheckAndroid
+   ```
+
+2. Run the following command to regenerate the Gradle wrapper:
+   ```bash
+   gradle -b regenerate-wrapper.gradle regenerateWrapper
+   ```
+   
+   If you don't have Gradle installed, you can install it from https://gradle.org/install/
+
+3. Alternatively, if you already have Gradle 7.4 installed, run:
+   ```bash
+   gradle wrapper --gradle-version 7.4 --distribution-type bin
+   ```
+
+4. Commit the changes:
+   ```bash
+   git add gradle/wrapper/gradle-wrapper.jar
+   git add gradle/wrapper/gradle-wrapper.properties
+   git add gradlew
+   git add gradlew.bat
+   git commit -m "Regenerate Gradle wrapper"
+   git push
+   ```

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -5,7 +5,7 @@
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/colorPrimaryDark</item>
         <item name="colorPrimaryDark">#000000</item>
-        <item name="colorAccent">@color/colorAccentDark</item>
+        <item name="colorAccent">@color/accent_dark</item>
         
         <!-- Card colors -->
         <item name="cardBackgroundColor">#2D2D2D</item>

--- a/regenerate-wrapper.gradle
+++ b/regenerate-wrapper.gradle
@@ -1,0 +1,4 @@
+task regenerateWrapper(type: Wrapper) {
+    gradleVersion = '7.4'
+    distributionType = 'bin'
+}


### PR DESCRIPTION
This PR combines all the necessary fixes to make the TixelCheckAndroid project compile successfully:

1. **Color Resource Fixes**:
   - Removed duplicate `colorAccentDark` from `values-night/colors.xml`
   - Fixed the night theme in `values-night/themes.xml` to use the existing `accent_dark` color instead of the non-existent `colorAccentDark`

2. **Gradle Wrapper Fix**:
   - Added a script (`regenerate-wrapper.gradle`) to regenerate the Gradle wrapper files
   - Added detailed instructions in `GRADLE-FIX.md` for generating the correct Gradle wrapper JAR file

## Required Steps After Merging

1. Clone the repository
2. Follow the instructions in GRADLE-FIX.md to regenerate the gradle-wrapper.jar
3. Push the updated wrapper files back to the repository

This PR supersedes both PR #10 and PR #11 and provides a complete solution to the compilation issues.